### PR TITLE
allow codespan to accept a custom componet

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ MTRC.configure({
 - **del**: this.props.children
 - **img**: this.props.src, this.props.alt
 - **code**: this.props.language, this.props.code
+- **codespan**: this.props.children
 
 ### Convert
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ renderer.em = function (text) {
 
 renderer.codespan = function (text) {
   var id = inlineIds++;
-  inlines[id] = React.createElement('code', {key: keys++}, he.decode(text));
+  inlines[id] = React.createElement(options.codespan || 'code', {key: keys++}, he.decode(text));
   return '{{' + id + '}}';
 };
 


### PR DESCRIPTION
Currently, only the ```code``` element can be customized. So marked is parsing a ```code``` element only when it's in multiple lines like this:

```
this is my code
```

However including code inline 👉 ```like this``` is parsed as a ```codespan```, and that cannot be customized with MTRC.