### PR TITLE
Fix DOM nesting in table element

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ MTRC.configure({
 - **ul**: this.props.children
 - **p**: this.props.children
 - **table**: this.props.children
+- **thead**: this.props.children
+- **tbody**: this.props.children
 - **tr**: this.props.children
 - **th**: this.props.children
 - **td**: this.props.children

--- a/src/index.js
+++ b/src/index.js
@@ -51,11 +51,11 @@ renderer.code = function (code, language) {
 
 renderer.blockquote = function (text) {
   var count = text.split(/(\{\{.*?\}\})/).filter(function(n){ return n != ""});
-  
+
   count.forEach(function(){
     result.pop();
   });
-  
+
   result.push(React.createElement(options.blockquote || 'blockquote', {key: keys++}, createBlockContent(text)));
 };
 
@@ -132,10 +132,22 @@ renderer.paragraph = function (text) {
 renderer.table = function (header, body) {
   var id = inlineIds++;
   inlines[id] =  React.createElement(options.table || 'table', {key: keys++},
-    createBlockContent(header),
-    createBlockContent(body)
+    React.createElement(options.thead || 'thead', null, createBlockContent(header)),
+    React.createElement(options.tbody || 'tbody', null, createBlockContent(body))
   );
   result.push(inlines[id]);
+  return '{{' + id + '}}';
+};
+
+renderer.thead = function (content) {
+  var id = inlineIds++;
+  inlines[id] = React.createElement(options.thead || 'thead', {key: keys++}, createBlockContent(content));
+  return '{{' + id + '}}';
+};
+
+renderer.tbody = function (content) {
+  var id = inlineIds++;
+  inlines[id] = React.createElement(options.tbody || 'tbody', {key: keys++}, createBlockContent(content));
   return '{{' + id + '}}';
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,9 +18,14 @@ var createBlockContent = function (content) {
     if (inline) {
       return inlines[inline[1]];
     } else {
-      return he.decode(text);
+			if (text != '') {
+      	return he.decode(text);
+			}
     }
   });
+
+	console.log(content)
+
   return content;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,6 @@ var createBlockContent = function (content) {
     }
   });
 
-	console.log(content)
-
   return content;
 };
 


### PR DESCRIPTION
Fix table render to use the markup tags `tbody` and `thead` avoiding the DOM nesting warning from react and build a more semantic result.

![screen shot 2017-03-09 at 4 16 35 pm](https://cloud.githubusercontent.com/assets/1891339/23766630/6ed90ee6-04e4-11e7-82dc-fd647aca6ede.png)

☝️ DOM nesting warning