### PR TITLE
Replacing Prism check from bool coercian to explicit type check

### DIFF
--- a/src/CodeComponent.js
+++ b/src/CodeComponent.js
@@ -2,14 +2,14 @@ var React = require('react');
 
 var CodeComponent = React.createClass({
   componentDidMount: function () {
-    if (!Prism) {
+    if (typeof Prism === 'undefined') {
       console.warn('You do not have Prism included as a global object');
       return;
     }
     Prism.highlightAll();
   },
   componentDidUpdate: function () {
-    if (!Prism) {
+    if (typeof Prism === 'undefined') {
       console.warn('You do not have Prism included as a global object');
       return;
     }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7850794/24632257/655c40c8-18bb-11e7-9148-03291ab883b0.png)

In stricter environments where `Prism` isn't present, an error is thrown. By replacing with a `typeof` check, the error is suppressed.