### PR TITLE
Updated with React 15.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # markdown-to-react-components
-Convert markdown into react components
+Convert markdown into react components (updated to React 15.6.1)
 
 ## DEPRECATED
 This repo is DEPRECATED, please go to: https://github.com/cerebral/marksy

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
   },
   "homepage": "https://github.com/christianalfoni/markdown-to-react-components",
   "devDependencies": {
+    "create-react-class": "^15.6.0",
     "css-loader": "^0.15.2",
     "json-loader": "^0.5.2",
     "node-libs-browser": "^0.5.2",
-    "react": "^0.14.7",
+    "react": "^15.6.1",
     "style-loader": "^0.12.3",
     "webpack": "^1.10.0",
     "webpack-dev-server": "^1.10.1"

--- a/src/CodeComponent.js
+++ b/src/CodeComponent.js
@@ -1,6 +1,7 @@
 var React = require('react');
+var createReactClass = require('create-react-class');
 
-var CodeComponent = React.createClass({
+var CodeComponent = createReactClass({
   componentDidMount: function () {
     if (typeof Prism === 'undefined') {
       console.warn('You do not have Prism included as a global object');


### PR DESCRIPTION
At Least Removes the warning
`Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class`